### PR TITLE
Removes the meteor gun pen from maintenance loot

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -322,7 +322,7 @@
 	if(toggle_action)
 		icon_state = "selfrepair_[on ? "on" : "off"]"
 	else
-		icon_state = "cyborg_upgrade5"
+		icon_state = "module_general"
 	return ..()
 
 /obj/item/borg/upgrade/selfrepair/proc/activate_sr()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -322,7 +322,7 @@
 	if(toggle_action)
 		icon_state = "selfrepair_[on ? "on" : "off"]"
 	else
-		icon_state = "module_general"
+		icon_state = "cyborg_upgrade5"
 	return ..()
 
 /obj/item/borg/upgrade/selfrepair/proc/activate_sr()

--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
@@ -4,7 +4,6 @@ GLOBAL_LIST_INIT(one_of_a_kind_loot, list(
 	/obj/item/melee/energy/sword/bananium,
 	/obj/item/dice/d20/teleporting_die_of_fate,
 	/obj/item/modular_computer/pda/clear,
-	/obj/item/gun/energy/meteorgun/pen,
 	/obj/item/hot_potato,
 	/obj/item/clothing/shoes/gunboots/disabler,
 	/obj/item/spear/grey_tide,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the meteor gun pen from maintenance loot. While it's only a 1 in 11,000 chance to pull from a spawner, it's still far too gamer-loot to have in maints, we've already had an instance of accidental meteoring with what is very much not obviously a weapon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Why are one-shot kill weapons even in maints anyway?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
removed: Meteor gun pen from maint loot pools.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
